### PR TITLE
Add the response_format parameter to completion of Chatgpt

### DIFF
--- a/src/ur/chatgpt.ur
+++ b/src/ur/chatgpt.ur
@@ -53,6 +53,8 @@ type model = string
 val read_model = _
 val show_model = _
 
+datatype response_format = AsJson | RegularText
+
 (* handling conversion between response_format and actual string *)
 val read_response_format = mkRead' (fn s =>
                             case s of

--- a/src/ur/chatgpt.ur
+++ b/src/ur/chatgpt.ur
@@ -53,9 +53,7 @@ type model = string
 val read_model = _
 val show_model = _
 
-datatype response_format = AsJson | RegularText
-type response_format' = variant [AsJson = unit, RegularText = unit]
-
+(* handling conversion between response_format and actual string *)
 val read_response_format = mkRead' (fn s =>
                             case s of
                                 "json_object" => Some AsJson

--- a/src/ur/chatgpt.ur
+++ b/src/ur/chatgpt.ur
@@ -53,22 +53,37 @@ type model = string
 val read_model = _
 val show_model = _
 
-type response_format = {
-    Type : string
-}
+datatype response_format = AsJson | RegularText
+type response_format' = variant [AsJson = unit, RegularText = unit]
 
-val _ : json response_format = json_record {Type = "type"}
+val read_response_format = mkRead' (fn s =>
+                            case s of
+                                "json_object" => Some AsJson
+                              | "text" => Some RegularText
+                              | _ => None)
+                        "response_format"
+
+val show_response_foramt = mkShow (fn x =>
+                           case x of
+                               AsJson => "json_object"
+                             | RegularText => "text")
+
+val json_response_format : json response_format = @json_derived Result.readResult show _
+
+type response_format_dict = {Type : response_format}
+
+val _ : json response_format_dict = json_record {Type = "type"}
 
 type completions_arg = {
      Model : model,
      Messages : list {Role : role,
                       Content : string},
-     ResponseFormat: {Type: string}
+     ResponseFormat: response_format_dict
 }
 val _ : json completions_arg = json_record
                                    {Model = "model",
                                     Messages = "messages",
-                                    ResponseFormat = "response_format"}
+                                    ResponseFormat = "response_format_dict"}
 
 functor Make(M : sig
                  val token : transaction (option string)

--- a/src/ur/chatgpt.ur
+++ b/src/ur/chatgpt.ur
@@ -53,14 +53,22 @@ type model = string
 val read_model = _
 val show_model = _
 
+type response_format = {
+    Type : string
+}
+
+val _ : json response_format = json_record {Type = "type"}
+
 type completions_arg = {
      Model : model,
      Messages : list {Role : role,
-                      Content : string}
+                      Content : string},
+     ResponseFormat: {Type: string}
 }
 val _ : json completions_arg = json_record
                                    {Model = "model",
-                                    Messages = "messages"}
+                                    Messages = "messages",
+                                    ResponseFormat = "response_format"}
 
 functor Make(M : sig
                  val token : transaction (option string)

--- a/src/ur/chatgpt.urs
+++ b/src/ur/chatgpt.urs
@@ -23,7 +23,8 @@ functor Make(M : sig
     structure Chat : sig
         val completions : {Model : model,
                            Messages : list {Role : role,
-                                            Content : string}}
+                                            Content : string},
+                            ResponseFormat: {Type: string}}
                           -> transaction string
     end
 end

--- a/src/ur/chatgpt.urs
+++ b/src/ur/chatgpt.urs
@@ -29,6 +29,9 @@ functor Make(M : sig
         val completions : {Model : model,
                            Messages : list {Role : role,
                                             Content : string},
+       (*The OpenAI documentation (found here: https://platform.openai.com/docs/api-reference/chat/create)
+        dictates that response type is a field of a dict with key "type". 
+        There are other values allowed in this dict, but we are only using "type" for now.*) 
                             ResponseFormat: {Type: response_format}}
                           -> transaction string
     end

--- a/src/ur/chatgpt.urs
+++ b/src/ur/chatgpt.urs
@@ -15,6 +15,11 @@ datatype role = System | User | Assistant
 val read_role : read role
 val show_role : show role
 
+(* Different response type we can ask the GPT to return *)
+datatype response_format = AsJson | RegularText
+val read_response_format : read response_format
+val show_response_foramt : show response_format
+
 (** * Now for the actual methods.... *)
 
 functor Make(M : sig
@@ -24,7 +29,7 @@ functor Make(M : sig
         val completions : {Model : model,
                            Messages : list {Role : role,
                                             Content : string},
-                            ResponseFormat: {Type: string}}
+                            ResponseFormat: {Type: response_format}}
                           -> transaction string
     end
 end


### PR DESCRIPTION
The completions function takes one more argument: ResponseFormat that can be either set of "text" or "json_object". 
We are guaranteed to obtain a Json object from ChatGPT is it is set to "json_object"